### PR TITLE
Fix z-index bugs in Chrome

### DIFF
--- a/slip.js
+++ b/slip.js
@@ -102,7 +102,7 @@
 window['Slip'] = (function(){
     'use strict';
 
-    var damnYouChrome = /Chrome\/[34]/.test(navigator.userAgent); // For bugs that can't be programmatically detected :(
+    var damnYouChrome = /Chrome\/34/.test(navigator.userAgent); // For bugs that can't be programmatically detected :(
     var needsBodyHandlerHack = damnYouChrome; // Otherwise I _sometimes_ don't get any touchstart events and only clicks instead.
     var compositorDoesNotOrderLayers = damnYouChrome; // Looks like WebKit bug #61824, but iOS Safari doesn't have that problem.
 


### PR DESCRIPTION
Now the regexp catches only Chrome/34, if you use [34] the regexp actually matches any number between 3 and 4, for instance Chrome/35 or Chrome/40 are matching the expression.
