### PR TITLE
Fire beforereorder even when using 'instant' drag mode.

### DIFF
--- a/slip.js
+++ b/slip.js
@@ -202,7 +202,9 @@ window['Slip'] = (function(){
                 this.target.node.style[transitionPrefix] = '';
 
                 if (!this.dispatch(this.target.originalTarget, 'beforewait')) {
+                  if (this.dispatch(this.target.originalTarget, 'beforereorder')) {
                     this.setState(this.states.reorder);
+                  }
                 } else {
                     var holdTimer = setTimeout(function(){
                         var move = this.getAbsoluteMovement();


### PR DESCRIPTION
Previously, when handling 'beforewait' to allow for 'instant' drag mode by
using event.preventDefault() the dragged item would go into reorder mode
without firing the 'beforereorder' event. This prevented the use case of
combining the 'instant' drag mode with handling 'beforereorder' to
prevent dragging of non-draggable items.
