### PR TITLE
CommonJS support.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "slip.js",
+  "version": "1.2.0",
+  "description": "A tiny library for interactive swiping and reordering of elements in lists on touch screens.",
+  "main": "slip.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pornel/slip"
+  },
+  "keywords": [
+    "sortable",
+    "reordering",
+    "touch"
+  ],
+  "author": "pornel",
+  "license": "BSD",
+  "bugs": {
+    "url": "https://github.com/pornel/slip/issues"
+  },
+  "homepage": "https://pornel.net/slip/"
+}

--- a/slip.js
+++ b/slip.js
@@ -99,7 +99,20 @@
     USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-window['Slip'] = (function(){
+(function (root, factory) {
+    if (typeof define === 'function' && define.amd) {
+        // AMD. Register as an anonymous module.
+        define([], factory);
+    } else if (typeof exports === 'object') {
+        // Node. Does not work with strict CommonJS, but
+        // only CommonJS-like environments that support module.exports,
+        // like Node.
+        module.exports = factory();
+    } else {
+        // Browser globals (root is window)
+        root.Slip = factory();
+  }
+}(this, function () {
     'use strict';
 
     var requestAnimFrame = window.requestAnimationFrame || window.mozRequestAnimationFrame || window.webkitRequestAnimationFrame || function(f){setTimeout(f,1)};
@@ -733,12 +746,5 @@ window['Slip'] = (function(){
         },
     };
 
-    // AMD
-    if ('function' === typeof define && define.amd) {
-        define(function(){
-            return Slip;
-        });
-    }
     return Slip;
-})();
-
+}));


### PR DESCRIPTION
UMD wrapper taken from [here](https://github.com/umdjs/umd/blob/master/returnExports.js#L41).

It would be great if you could also push it to npm registry.
