### PR TITLE
Prevent updating position without target

### DIFF
--- a/slip.js
+++ b/slip.js
@@ -626,6 +626,8 @@ window['Slip'] = (function(){
         },
 
         updatePosition: function(e, pos) {
+            if(this.target == null)
+                return;
             this.latestPosition = pos;
 
             var triggerOffset = 40,


### PR DESCRIPTION
When scrolling a list on mobile, Slip attempts to update positions even
though no element is grabbed. That's problematic, as we have no target
object, so let's just not do that. This fixes #32 . No hard feelings if you deem this solution too hacky, and don't accept it. There might be more appropriate places to stop this behaviour, but this works perfectly and doesn't break anything in my experience.