### PR TITLE
Only regiter listener for selectionchange on IOS

### DIFF
--- a/slip.js
+++ b/slip.js
@@ -572,15 +572,16 @@ window['Slip'] = (function(){
 
         onSelection: function(e) {
             var isRelated = e.target === document || this.findTargetNode(e);
+            var iOS = /(iPhone|iPad|iPod)/i.test(navigator.userAgent) && !/(Android|Windows)/i.test(navigator.userAgent);
             if (!isRelated) return;
 
-            if (e.cancelable || e.defaultPrevented) {
+            if (iOS) {
+                // iOS doesn't allow selection to be prevented
+                this.setState(this.states.idle);
+            } else {
                 if (!this.state.allowTextSelection) {
                     e.preventDefault();
                 }
-            } else {
-                // iOS doesn't allow selection to be prevented
-                this.setState(this.states.idle);
             }
         },
 


### PR DESCRIPTION
I have a strange problem with slip on chrome, IE and firefox with the `dom.select_events.enabled` set to true (as describe [here](https://developer.mozilla.org/en-US/docs/Web/Events/selectionchange#Browser_compatibility)): the `onSelection` callback is fired before the `holdTimer` can complete. That prevent the reordering to work. To get it working, I have to first click on on the draggable element and only then reorder. Here are examples of this:

- [example with the problem](https://mf-geoadmin3.dev.bgdi.ch/dnd-slipjs/?lang=fr&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&X=190000.00&Y=660000.00&zoom=1&dev3d=true&debug&layers=ch.swisstopo.swisstlm3d-wanderwege,ch.swisstopo.zeitreihen,ch.bfs.gebaeude_wohnungs_register,ch.bafu.wrz-wildruhezonen_portal,ch.swisstopo.pixelkarte-farbe-pk200.noscale,ch.swisstopo.pixelkarte-farbe-pk100.noscale,ch.bfs.arealstatistik-1985,ch.bafu.biogeographische_regionen,ch.swisstopo.pixelkarte-farbe-pk500.noscale,ch.swisstopo.vec200-landcover,ch.swisstopo.pixelkarte-farbe-pk1000.noscale,ch.bfs.arealstatistik-waldmischungsgrad,ch.bfs.arealstatistik-bodenbedeckung-1985,ch.swisstopo.pixelkarte-farbe-pk50.noscale&layers_visibility=false,false,false,false,true,true,true,true,true,false,true,true,true,true&layers_timestamp=,18641231,,,,,,,,,,,,&catalogNodes=457,477&layers_opacity=1,1,1,1,1,1,0.75,0.75,1,0.75,1,0.75,0.75,1): In order to reorder of the selected maps on Chrome or IE, you need to first click on a map.
- [example with this patch](http://mapwork.ioda-net.ch/?lang=en&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.bfs.gebaeude_wohnungs_register,ch.swisstopo.zeitreihen,ch.swisstopo.swisstlm3d-wanderwege,ch.bafu.wrz-wildruhezonen_portal&layers_visibility=false,false,false,false&layers_timestamp=,18641231,,): you can reorder the maps right away.

From what I understand of the comment, this listener is only relevant for ios devices, so it shouldn't have an impact on other platforms. Strangely, your demo is not affected by this.