### PR TITLE
Fix dragging first or last element of list where spliceIndex is same as originalIndex

### DIFF
--- a/slip.js
+++ b/slip.js
@@ -454,21 +454,25 @@ window['Slip'] = (function(){
 
                     onEnd: function() {
                         var move = this.getTotalMovement();
+                        var i, spliceIndex;
                         if (move.y < 0) {
-                            for(var i=0; i < otherNodes.length; i++) {
+                            for (i=0; i < otherNodes.length; i++) {
                                 if (otherNodes[i].pos > move.y) {
-                                    this.dispatch(this.target.node, 'reorder', {spliceIndex:i, insertBefore:otherNodes[i].node, originalIndex: originalIndex});
                                     break;
                                 }
                             }
+                            spliceIndex = i;
                         } else {
-                            for(var i=otherNodes.length-1; i >= 0; i--) {
+                            for (i=otherNodes.length-1; i >= 0; i--) {
                                 if (otherNodes[i].pos < move.y) {
-                                    this.dispatch(this.target.node, 'reorder', {spliceIndex:i+1, insertBefore:otherNodes[i+1] ? otherNodes[i+1].node : null, originalIndex: originalIndex});
                                     break;
                                 }
                             }
+                            spliceIndex = i+1;
                         }
+
+                        this.dispatch(this.target.node, 'reorder', {spliceIndex:spliceIndex, insertBefore:otherNodes[spliceIndex] ? otherNodes[spliceIndex].node : null, originalIndex: originalIndex});
+
                         this.setState(this.states.idle);
                         return false;
                     },


### PR DESCRIPTION
When dragging first or last element of the list, the logic to determine the new spliceIndex was not always working if spliceIndex ended up the same as originalIndex. This would result in no 'slip:reorder' event firing on mouseup/touchup.

This pull request fixes this by handling the edge cases of searching the list of otherNodes and not finding a node that satisifes the condition of "otherNode.pos > move.y" (or < move.y, when moving the other way).

This is a possible fix for issue #65.