### PR TITLE
Only fire slip:swipe or slip:cancelswipe, not both

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ You interact with the library via custom DOM events for swipes/reordering.  Call
     If you execute `event.preventDefault()` then the element will not move at all.
     Parent element will have class `slip-swiping-container` for duration of the animation.
 
+* `slip:cancelswipe`
+
+    Fired after the user has started to swipe, but lets go without actually swiping left or right.
+
 * `slip:reorder`
 
     Element has been dropped in new location. `event.detail` contains the location:
@@ -44,10 +48,6 @@ You interact with the library via custom DOM events for swipes/reordering.  Call
 * `slip:tap`
 
     When element was tapped without being swiped/reordered.
-
-* `slip:cancelswipe`
-
-    Fired when the user stops dragging and the element returns to its original position.
 
 ### Example
 

--- a/slip.js
+++ b/slip.js
@@ -12,6 +12,9 @@
             Fired before first swipe movement starts.
             If you execute event.preventDefault() then element will not move at all.
 
+        • slip:cancelswipe
+            Fired after the user has started to swipe, but lets go without actually swiping left or right.
+
         • slip:reorder
             Element has been dropped in new location. event.detail contains the location:
                 • insertBefore: DOM node before which element has been dropped (null is the end of the list). Use with node.insertBefore().
@@ -28,9 +31,6 @@
 
         • slip:tap
             When element was tapped without being swiped/reordered.
-
-        • slip:cancelswipe
-            Fired when the user stops dragging and the element returns to its original position.
 
 
     Usage:
@@ -318,7 +318,6 @@ window['Slip'] = (function(){
                             }.bind(this));
                         } else {
                             this.animateToZero(removeClass);
-                            this.dispatch(this.target.node, 'cancelswipe');
                         }
                     },
 
@@ -350,6 +349,8 @@ window['Slip'] = (function(){
                             if (this.dispatch(this.target.node, 'swipe', {direction: move.directionX, originalIndex: originalIndex})) {
                                 swipeSuccess = true; // can't animate here, leaveState overrides anim
                             }
+                        } else {
+                            this.dispatch(this.target.node, 'cancelswipe');
                         }
                         this.setState(this.states.idle);
                         return !swiped;


### PR DESCRIPTION
Previously, if you called `e.preventDefault()` in a `slip:swipe` handler, in addition to animating the element back to zero, it would also call `slip:cancelswipe`.  However, this is unintuitive, and error-prone for most uses.  It seems to me that after `slip:beforeswipe`, only one of `slip:swipe` or `slip:cancelswipe` should be fired.  There was no way to know that `slip:cancelswipe` was being fired for this reason, and not because it was actually cancelled (i.e. the user let go without actually swiping left or right).

Until making this fix, I had to add some ugly workarounds and flags in all my code that used slip.js and depended on the `slip:cancelswipe` event.
