### PR TITLE
Fix calculation of scrollContainer, so it stops at document.body

### DIFF
--- a/slip.js
+++ b/slip.js
@@ -665,8 +665,9 @@ window['Slip'] = (function(){
             //check for a scrollable parent
             var scrollContainer = targetNode.parentNode;
             while (scrollContainer){
+              if (scrollContainer == document.body) break;
               if (scrollContainer.scrollHeight > scrollContainer.clientHeight && window.getComputedStyle(scrollContainer)['overflow-y'] != 'visible') break;
-              else scrollContainer = scrollContainer.parentNode;
+              scrollContainer = scrollContainer.parentNode;
             }
 
             this.target = {


### PR DESCRIPTION
This fixes the calculation of `scrollContainer`, so it doesn't keep going all the way up to the `html` element, but stops at `body`.  I've run into this in some cases.

`scrollContainer.scrollTop` is set in the scrolling logic, but the `html` element ignores changes to `.scrollTop`.

Possible fix for issue #53.
