### PR TITLE
Add animateswipe event

### DIFF
--- a/slip.js
+++ b/slip.js
@@ -15,6 +15,12 @@
         • slip:cancelswipe
             Fired after the user has started to swipe, but lets go without actually swiping left or right.
 
+        • slip:animateswipe
+            Fired while swiping, before the user has let go of the element.
+            event.detail.x contains the amount of movement in the x direction.
+            If you execute event.preventDefault() then the element will not move to this position.
+            This can be useful for saturating the amount of swipe, or preventing movement in one direction, but allowing it in the other.
+
         • slip:reorder
             Element has been dropped in new location. event.detail contains the location:
                 • insertBefore: DOM node before which element has been dropped (null is the end of the list). Use with node.insertBefore().
@@ -325,7 +331,9 @@ window['Slip'] = (function(){
                         var move = this.getTotalMovement();
 
                         if (Math.abs(move.y) < this.target.height+20) {
-                            this.target.node.style[transformJSPropertyName] = 'translate(' + move.x + 'px,0) ' + hwLayerMagicStyle + this.target.baseTransform.value;
+                            if (this.dispatch(this.target.node, 'animateswipe', {x: move.x, originalIndex: originalIndex})) {
+                                this.target.node.style[transformJSPropertyName] = 'translate(' + move.x + 'px,0) ' + hwLayerMagicStyle + this.target.baseTransform.value;
+                            }
                             return false;
                         } else {
                             this.setState(this.states.idle);

--- a/slip.js
+++ b/slip.js
@@ -336,6 +336,7 @@ window['Slip'] = (function(){
                             }
                             return false;
                         } else {
+                            this.dispatch(this.target.node, 'cancelswipe');
                             this.setState(this.states.idle);
                         }
                     },


### PR DESCRIPTION
I added this `slip:animateswipe` event to support the display of some icons "behind" the element being swiped, e.g. to show a delete icon.  All of the logic to show the icon is in my app, but this event made it possible.  Seems generally useful.

I considered something similar for `slip:animatereorder`, but it would be considerably more complex, and I don't see the obvious use case, so it's not in this pull request.

Also, it makes sense to emit `slip:cancelswipe` when the user drags far enough up or down to cancel the swipe.  This way, after emitting `slip:beforeswipe`, we always emit either `slip:cancelswipe` or `slip:swipe`.  This change was also necessary to make my swipe icons work properly.
