### PR TITLE
Scroll example

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,18 +27,25 @@ You interact with the library via custom DOM events for swipes/reordering.  Call
 
     Fired after the user has started to swipe, but lets go without actually swiping left or right.
 
+* `slip:animateswipe`
+
+    Fired while swiping, before the user has let go of the element.
+    `event.detail.x` contains the amount of movement in the x direction.
+    If you execute `event.preventDefault()` then the element will not move to this position.
+    This can be useful for saturating the amount of swipe, or preventing movement in one direction, but allowing it in the other.
+
 * `slip:reorder`
 
-    Element has been dropped in new location. `event.detail` contains the location:
+    Element has been dropped in new location. `event.detail` contains the following:
 
     * `insertBefore`: DOM node before which element has been dropped (`null` is the end of the list). Use with `node.insertBefore()`.
     * `spliceIndex`: Index of element before which current element has been dropped, not counting the element iself. For use with `Array.splice()` if the list is reflecting objects in some array.
-    * `originalIndex`: The original index of the element.
+    * `originalIndex`: The original index of the element before it was reordered.
 
 * `slip:beforereorder`
 
     When reordering movement starts.
-    Element being dragged gets `slip-reordering` class.
+    Element being reordered gets class `slip-reordering`.
     If you execute `event.preventDefault()` then the element will not move at all.
 
 * `slip:beforewait`
@@ -48,6 +55,7 @@ You interact with the library via custom DOM events for swipes/reordering.  Call
 * `slip:tap`
 
     When element was tapped without being swiped/reordered.
+
 
 ### Example
 
@@ -123,6 +131,13 @@ Class `slip-reordering` is set on list element that is being dragged:
 ```css
 .slip-reordering {
     box-shadow: 0 2px 10px rgba(0,0,0,0.45);
+}
+```
+
+When an item is dragged, `z-index` is set to 99999 on the element, so that it floats above the other elements in the list.  In order to make this effective in some browsers, you'll need to set `position: relative` on the list items.
+```css
+li {
+    position: relative;
 }
 ```
 

--- a/example.html
+++ b/example.html
@@ -13,7 +13,7 @@
     overflow-x: hidden;
 }
 
-#slippylist li {
+.slippylist li {
     user-select: none;
     -moz-user-select: none;
     -webkit-user-select: none;
@@ -21,14 +21,14 @@
 }
 
 /* the rest is junk for the demo page */
-#slippylist li.demo-allow-select {
+.slippylist li.demo-allow-select {
     padding: 1em;
     line-height: 1.3;
     user-select: text;
     -moz-user-select: text;
     -webkit-user-select: text;
 }
-#slippylist li.demo-allow-select span {
+.slippylist li.demo-allow-select span {
     cursor: text;
 }
 
@@ -40,13 +40,13 @@ body {
     padding: 5px;
 }
 
-#slippylist {
+.slippylist {
     clear:left;
     margin: 1em;
     padding: 0 0 1px;
 }
 
-#slippylist li {
+.slippylist li {
     display:block;
     border: 1px solid black;
     background: white;
@@ -58,14 +58,14 @@ body {
     vertical-align: middle;
 }
 
-#slippylist input {
+.slippylist input {
     vertical-align: middle;
 }
 
-#slippylist .instant::after {
+.slippylist .instant::after {
     content: " \2261";
 }
-#slippylist .instant {
+.slippylist .instant {
     float: right;
 }
 
@@ -76,6 +76,11 @@ body {
 
 .demo-no-swipe.demo-no-reorder {
     opacity: 0.5;
+}
+
+#scroll {
+    overflow-y: scroll;
+    max-height: 300px;
 }
 
 h1, h2 {
@@ -91,7 +96,7 @@ h1+p {
 <body>
 <h1>Slip.js</h1>
 <p>Swiping and reordering lists of elements on touch screens, no fuss. A&nbsp;tiny library by <a href="//twitter.com/kornelski">Kornel</a>.</p>
-<ol id="slippylist">
+<ol id="demo1" class="slippylist">
     <li class="demo-no-reorder">Swipe,</li>
     <li class="demo-no-swipe">hold &amp; reorder <span class="instant">or instantly</span></li>
     <li>or either</li>
@@ -107,6 +112,25 @@ h1+p {
     <li>Opera Presto and Blink</li>
     <li>No dependencies</li>
 </ol>
+<h3>Demo inside of a scroll container</h3>
+<div id="scroll">
+<ol id="demo2" class="slippylist">
+    <li class="demo-no-reorder">Swipe,</li>
+    <li class="demo-no-swipe">hold &amp; reorder <span class="instant">or instantly</span></li>
+    <li>or either</li>
+    <li class="demo-no-swipe demo-no-reorder">or none of them.</li>
+    <li>Can play nicely with:</li>
+    <li>interaction <input type="range"></li>
+    <li style="transform: scaleX(0.97) skewX(-10deg); -webkit-transform: scaleX(0.97) skewX(-10deg)">inline CSS transforms</li>
+    <li class="skewed">stylesheet transforms</li>
+    <li class="demo-allow-select"><span class="demo-no-reorder">and selectable text, even though animating elements with selected text is a bit weird.</span></li>
+    <li>iOS Safari</li>
+    <li>Mobile Chrome</li>
+    <li>Android Firefox</li>
+    <li>Opera Presto and Blink</li>
+    <li>No dependencies</li>
+</ol>
+</div>
 <h2>Known limitations</h2>
 <ul>
     <li>Tap &amp; hold is too sensitive in Firefox (W3C TouchEvents specification is ambiguous about sensitivity of touch movements, so strictly speaking that's a spec bug, not a browser bug.)</li>
@@ -115,31 +139,34 @@ h1+p {
 <p><a href="https://github.com/pornel/slip">Bug/fork/star on GitHub</a>.</p>
 <script src="slip.js"></script>
 <script>
-    var ol = document.getElementById('slippylist');
-    ol.addEventListener('slip:beforereorder', function(e){
-        if (/demo-no-reorder/.test(e.target.className)) {
-            e.preventDefault();
-        }
-    }, false);
+    function setupSlip(list) {
+        list.addEventListener('slip:beforereorder', function(e){
+            if (/demo-no-reorder/.test(e.target.className)) {
+                e.preventDefault();
+            }
+        }, false);
 
-    ol.addEventListener('slip:beforeswipe', function(e){
-        if (e.target.nodeName == 'INPUT' || /demo-no-swipe/.test(e.target.className)) {
-            e.preventDefault();
-        }
-    }, false);
+        list.addEventListener('slip:beforeswipe', function(e){
+            if (e.target.nodeName == 'INPUT' || /demo-no-swipe/.test(e.target.className)) {
+                e.preventDefault();
+            }
+        }, false);
 
-    ol.addEventListener('slip:beforewait', function(e){
-        if (e.target.className.indexOf('instant') > -1) e.preventDefault();
-    }, false);
+        list.addEventListener('slip:beforewait', function(e){
+            if (e.target.className.indexOf('instant') > -1) e.preventDefault();
+        }, false);
 
-    ol.addEventListener('slip:afterswipe', function(e){
-        e.target.parentNode.appendChild(e.target);
-    }, false);
+        list.addEventListener('slip:afterswipe', function(e){
+            e.target.parentNode.appendChild(e.target);
+        }, false);
 
-    ol.addEventListener('slip:reorder', function(e){
-        e.target.parentNode.insertBefore(e.target, e.detail.insertBefore);
-        return false;
-    }, false);
+        list.addEventListener('slip:reorder', function(e){
+            e.target.parentNode.insertBefore(e.target, e.detail.insertBefore);
+            return false;
+        }, false);
+        return new Slip(list);
+    }
+    setupSlip(document.getElementById('demo1'));
+    setupSlip(document.getElementById('demo2'));
 
-    new Slip(ol);
 </script>

--- a/example.html
+++ b/example.html
@@ -47,7 +47,8 @@ body {
 }
 
 .slippylist li {
-    display:block;
+    display: block;
+    position: relative;
     border: 1px solid black;
     background: white;
     margin: 0; padding: 0 1em;
@@ -83,14 +84,21 @@ body {
     max-height: 300px;
 }
 
-h1, h2 {
+h1, h2, h3 {
     color: #666;
 }
 h1 {
-    float:left; margin-top: 0; margin-right: 1ex;
+    float:left;
+    margin-top: 0;
+    margin-right: 1ex;
+}
+h3 {
+    margin-bottom: 0.2em;
+    margin-top: 2em;
 }
 h1+p {
-    overflow:auto; margin-top: 0.2em;
+    overflow:auto;
+    margin-top: 0.2em;
 }
 </style>
 <body>

--- a/slip.js
+++ b/slip.js
@@ -22,21 +22,22 @@
             This can be useful for saturating the amount of swipe, or preventing movement in one direction, but allowing it in the other.
 
         • slip:reorder
-            Element has been dropped in new location. event.detail contains the location:
+            Element has been dropped in new location. event.detail contains the following:
                 • insertBefore: DOM node before which element has been dropped (null is the end of the list). Use with node.insertBefore().
                 • spliceIndex: Index of element before which current element has been dropped, not counting the element iself.
                                For use with Array.splice() if the list is reflecting objects in some array.
+                • originalIndex: The original index of the element before it was reordered.
 
         • slip:beforereorder
             When reordering movement starts.
             Element being reordered gets class `slip-reordering`.
-            If you execute event.preventDefault() then element will not move at all.
+            If you execute event.preventDefault() then the element will not move at all.
 
         • slip:beforewait
             If you execute event.preventDefault() then reordering will begin immediately, blocking ability to scroll the page.
 
         • slip:tap
-            When element was tapped without being swiped/reordered.
+            When element was tapped without being swiped/reordered. You can check `event.target` to limit that behavior to drag handles.
 
 
     Usage:


### PR DESCRIPTION
Add demo of using slip inside of a scrolling div, instead of scrolling the entire page.  If nothing else, this is useful for testing.

Also fix an issue where the `z-index` would not be honored, by adding `position: relative` to list items in the example.  See issue #49.
