### PR TITLE
Use exact match on classList instead of regex on className to test CSS classes

### DIFF
--- a/example.html
+++ b/example.html
@@ -149,19 +149,19 @@ h1+p {
 <script>
     function setupSlip(list) {
         list.addEventListener('slip:beforereorder', function(e){
-            if (/demo-no-reorder/.test(e.target.className)) {
+            if (e.target.classList.indexOf('demo-no-reorder') >= 0) {
                 e.preventDefault();
             }
         }, false);
 
         list.addEventListener('slip:beforeswipe', function(e){
-            if (e.target.nodeName == 'INPUT' || /demo-no-swipe/.test(e.target.className)) {
+            if (e.target.nodeName == 'INPUT' || e.target.classList.indexOf('demo-no-swipe') >= 0) {
                 e.preventDefault();
             }
         }, false);
 
         list.addEventListener('slip:beforewait', function(e){
-            if (e.target.className.indexOf('instant') > -1) e.preventDefault();
+            if (e.target.classList.indexOf('instant') >= 0) e.preventDefault();
         }, false);
 
         list.addEventListener('slip:afterswipe', function(e){

--- a/testDetach.html
+++ b/testDetach.html
@@ -124,7 +124,7 @@ h1+p {
 <script src="slip.js"></script>
 <script>
     function beforereorder(e) {
-        if (/demo-no-reorder/.test(e.target.className)) {
+        if (e.target.classList.indexOf('demo-no-reorder') >= 0) {
             e.preventDefault();
         }
     }
@@ -145,7 +145,7 @@ h1+p {
     function Attach(e) {
       e.target.removeEventListener('click', Attach, false);
       document.demo1SlipObj = setupSlip(document.getElementById('demo1'));
-      
+
       document.getElementById("detach").addEventListener('click', Detach, false);
     }
 


### PR DESCRIPTION
As mentioned in #79, use exact matches on `classList` instead of using regexes to match on `className`.